### PR TITLE
修复video不能有效设置style问题

### DIFF
--- a/components/gaoyia-parse/components/wxParseVideo.vue
+++ b/components/gaoyia-parse/components/wxParseVideo.vue
@@ -1,7 +1,7 @@
 <template>
   <!--增加video标签支持，并循环添加-->
   <view :class="node.classStr" :style="node.styleStr">
-    <video :class="node.classStr" class="video-video" :src="node.attr.src"></video>
+    <video :class="node.classStr" :style="node.styleStr" class="video-video" :src="node.attr.src"></video>
   </view>
 </template>
 


### PR DESCRIPTION
表现(补充: 本意是想填充满屏幕宽度, 但style没传到video, video就使用了uniapp video组件的默认值):
![image](https://user-images.githubusercontent.com/8316403/60090730-ab27f080-9775-11e9-80cc-d47f2cba8509.png)
`content`传入的<u-parse>值:
![image](https://user-images.githubusercontent.com/8316403/60090797-c692fb80-9775-11e9-8fed-5a176a27cf62.png)
